### PR TITLE
Remove the Router path within Switch, since it duplicates the HTML body

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -8,7 +8,6 @@ export const AppRouter: React.StatelessComponent<{}> = () => {
             <div className="container-fluid">
                 <Route component={App} />
                 <Switch>
-                    <Route exact path="/" component={App} />
                 </Switch>
             </div>
         </Router>


### PR DESCRIPTION
Remove the Router path within Switch, since it duplicates the HTML body on the local environment (although doesn't repro in Github site).

