### PR TITLE
Remove white circle

### DIFF
--- a/src/components/Agenda.css
+++ b/src/components/Agenda.css
@@ -79,6 +79,6 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  -webkit-box-shadow: 0 0 !important;
-  box-shadow: 0 0 !important;
+  -webkit-box-shadow: 0px 0px !important;
+  box-shadow: 0px 0px !important;
 }

--- a/src/components/Agenda.css
+++ b/src/components/Agenda.css
@@ -79,8 +79,6 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  -webkit-box-shadow: 0 0 0 4px transparent, inset 0 2px 0 transparent,
-    0 3px 0 4px transparent;
-  box-shadow: -4 0 0 0px transparent, inset 0 0px 0 transparent,
-    0 3px 0 4px transparent;
+  -webkit-box-shadow: 0 0 !important;
+  box-shadow: 0 0 !important;
 }


### PR DESCRIPTION
That white circle is generated by the box-shadow property. Set box-shadow horizontal and vertical offset as 0px, and use !important option to ensure this setting being picked.